### PR TITLE
Set scopes of credentials read from JSON.

### DIFF
--- a/google-analytics-data/src/main/java/com/google/analytics/data/samples/QuickstartJsonCredentialsSample.java
+++ b/google-analytics-data/src/main/java/com/google/analytics/data/samples/QuickstartJsonCredentialsSample.java
@@ -69,7 +69,10 @@ public class QuickstartJsonCredentialsSample {
     // Explicitly use service account credentials by specifying
     // the private key file.
     GoogleCredentials credentials =
-        GoogleCredentials.fromStream(new FileInputStream(credentialsJsonPath));
+        GoogleCredentials.fromStream(new FileInputStream(credentialsJsonPath))
+            .createScoped(
+                "https://www.googleapis.com/auth/analytics.readonly",
+                "https://www.googleapis.com/auth/analytics");
 
     BetaAnalyticsDataSettings betaAnalyticsDataSettings =
         BetaAnalyticsDataSettings.newBuilder()


### PR DESCRIPTION
This is required for certain use cases including impersonated service account credentials.